### PR TITLE
improve startup reliability

### DIFF
--- a/runner.vm/files/usr/lib/systemd/system/gcpnetwork.service
+++ b/runner.vm/files/usr/lib/systemd/system/gcpnetwork.service
@@ -4,8 +4,9 @@ Before=network-online.target
 OnFailure=poweroff.target
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/local/sbin/network.sh
+RemainAfterExit=yes
 StandardOutput=journal+console
 StandardError=journal+console
 

--- a/runner.vm/files/usr/lib/systemd/system/runner.service
+++ b/runner.vm/files/usr/lib/systemd/system/runner.service
@@ -5,7 +5,7 @@ OnFailure=poweroff.target
 OnSuccess=poweroff.target
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/local/bin/runner.sh
 User=enf
 WorkingDirectory=~

--- a/runner.vm/files/usr/local/bin/runner.sh
+++ b/runner.vm/files/usr/local/bin/runner.sh
@@ -7,9 +7,11 @@ GITHUB_RUNNER_REG_URL=$(${CURL} "http://metadata.google.internal/computeMetadata
 GITHUB_RUNNER_TOKEN=$(${CURL} "http://metadata.google.internal/computeMetadata/v1/instance/attributes/runnerToken" -H "Metadata-Flavor: Google")
 GITHUB_RUNNER_LABEL=$(${CURL} "http://metadata.google.internal/computeMetadata/v1/instance/attributes/runnerLabel" -H "Metadata-Flavor: Google")
 
-RUNNER_RELEASE_URL=$(${CURL} https://api.github.com/repos/actions/runner/releases | \
-	             jq -r 'first(.[] | select(.prerelease == false)) | .assets[] | if .name | test("actions-runner-linux-x64-[0-9.]+.tar") then .browser_download_url else empty end')
-${CURL} "${RUNNER_RELEASE_URL}" | tar zx
+RUNNER_RELEASE_URL=$(${CURL} https://api.github.com/repos/actions/runner/releases/latest | \
+                     jq -e -r '.assets[] | if .name | test("actions-runner-linux-x64-[0-9.]+.tar") then .browser_download_url else empty end')
+${CURL} -O "${RUNNER_RELEASE_URL}"
+tar xf *.tar.*
+rm *.tar.*
 
-./config.sh --url ${GITHUB_RUNNER_REG_URL} --token ${GITHUB_RUNNER_TOKEN} --ephemeral --disableupdate --unattended --labels ${GITHUB_RUNNER_LABEL}
+./config.sh --url "${GITHUB_RUNNER_REG_URL}" --token "${GITHUB_RUNNER_TOKEN}" --ephemeral --disableupdate --unattended --labels "${GITHUB_RUNNER_LABEL}"
 ./run.sh

--- a/runner.vm/files/usr/local/sbin/network.sh
+++ b/runner.vm/files/usr/local/sbin/network.sh
@@ -19,6 +19,12 @@ sysctl -q -w net.ipv6.conf.eth0.disable_ipv6=1
 ip addr add 169.254.0.0/16 dev eth0
 ip link set eth0 up
 
+tries=100
+until eval '(( $(< /sys/class/net/eth0/carrier) ))'; do
+   (( tries-- > 0 )) || exit 1
+   sleep 0.1
+done
+
 echo $(get_metadata name) > /proc/sys/kernel/hostname
 
 IP=$(get_metadata network-interfaces/0/ip)


### PR DESCRIPTION
* systemd units for network & runner really should be "oneshot" (I'm not a little uncertain how it worked previously with "simple")
* wait for network interface to indicate "up" before using the network
* simplify selection of runner release to use (just use "latest")
* don't pipe the runner download directly to tar: hopefully it can be retried more reliably that way