### PR TITLE
add docker buildx to the runner image

### DIFF
--- a/runner.vm/Dockerfile.root
+++ b/runner.vm/Dockerfile.root
@@ -3,6 +3,7 @@ RUN pacman -Syyu --noconfirm && pacman --noconfirm -S mkinitcpio
 RUN sed -i 's/MODULES=()/MODULES=(ext4 virtio virtio_pci virtio_net virtio_scsi)/' /etc/mkinitcpio.conf
 RUN pacman --noconfirm -S dhcpcd \
                           docker \
+                          docker-buildx \
                           git \
                           jq \
                           linux


### PR DESCRIPTION
The `docker/build-push-action@v3` action requires docker's buildx plugin, but at some point around Sep 2022 buildx was removed from Arch's `docker` package and placed instead in another optional package `docker-buildx`. Install `docker-buildx` so `docker/build-push-action@v3` continues to work.